### PR TITLE
fix: disabled user ability to make price/count values neg in updateItem

### DIFF
--- a/src/components/AddItem/AddItem.tsx
+++ b/src/components/AddItem/AddItem.tsx
@@ -163,8 +163,8 @@ export const AddItem = ({ setValue }: { setValue?: Function }) => {
                 inputRef={ref}
                 label="Item Name"
                 variant="outlined"
-                error={!!errors.price}
-                helperText={errors.price ? errors.price?.message : ""}
+                error={!!errors.itemName}
+                helperText={errors.itemName ? errors.itemName?.message : ""}
               />
             )}
           />

--- a/src/components/UpdateItem/UpdateItem.tsx
+++ b/src/components/UpdateItem/UpdateItem.tsx
@@ -149,6 +149,7 @@ export const UpdateItem = ({
             type="number"
             label="Count"
             name="count"
+            inputProps={{ inputMode: 'numeric', min: 0 }}
             value={formData.count}
             onChange={handleChange}
           />
@@ -179,6 +180,7 @@ export const UpdateItem = ({
             type="number"
             label="Price"
             name="price"
+            inputProps={{ inputMode: "decimal", min: 0, step: ".01" }}
             value={formData.price}
             onChange={handleChange}
           />


### PR DESCRIPTION
- Passed itemprops attribute to text fields in updateitem set a 0 min value and can't enter a negative sign
- Found/fix a bug that would show a numeric error message if there was a error in the itemName text field 