### PR TITLE
Fixed Summary Stack on log in, styling of summary stack and sidebar

### DIFF
--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -37,6 +37,14 @@ interface Props {
 
 export const SideBar = ({ window }: Props) => {
   const [mobileOpen, setMobileOpen] = React.useState(false);
+  const [selectedIndex, setSelectedIndex] = React.useState(0);
+
+  const handleListItemClick = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    index: number,
+  ) => {
+    setSelectedIndex(index);
+  };
 
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen);
@@ -95,7 +103,11 @@ export const SideBar = ({ window }: Props) => {
       <List>
         {items.map((item, index) => (
           <Link to={item.path} key={item.id} style={{}}>
-            <ListItem button>
+            <ListItem 
+              button 
+              selected={selectedIndex === index} 
+              onClick={(event) => handleListItemClick(event, index)}
+            >
               <ListItemIcon>{item.icon}</ListItemIcon>
               <ListItemText primary={item.name} />
             </ListItem>

--- a/src/components/SummaryStack/SummaryStack.tsx
+++ b/src/components/SummaryStack/SummaryStack.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { Box, Stack, Divider, Typography } from "@mui/material";
 import { useLocations } from "../../hooks/useLocations";
 import { useItems } from "../../context";
@@ -6,8 +6,13 @@ import { useCount } from "../../hooks/useCount";
 
 const SummaryStack = () => {
   const { locations } = useLocations();
-  const { items } = useItems();
+  const { items, listItems } = useItems();
   const { count } = useCount();
+
+  // Needed since although listItems is called when App is mounted, items array is empty
+  useEffect(() => {
+    listItems();
+  }, []);
 
   return (
     <Box>

--- a/src/components/SummaryStack/SummaryStack.tsx
+++ b/src/components/SummaryStack/SummaryStack.tsx
@@ -12,9 +12,9 @@ const SummaryStack = () => {
   return (
     <Box>
       <Stack
-        direction="row"
+        direction={{ xs: "column", sm: "column", md: "row" }}
         divider={<Divider orientation="vertical" flexItem />}
-        spacing={2}
+        spacing={{ xs: 1, sm: 1, md: 2 }}
         mb={3}
       >
         <Typography variant="h5">{`Total Locations: ${


### PR DESCRIPTION
- Fixed issue again where numerical data based on items isn't displayed after log in
- Added breakpoints to summary stack to be shown in a column on mobile
- Styled the sidebar so now when any page list item is clicked by user, the bgcolor of list item is now grey 